### PR TITLE
docs: fix missing annotation

### DIFF
--- a/libspiel/spiel-speaker.c
+++ b/libspiel/spiel-speaker.c
@@ -161,7 +161,7 @@ _queue_entry_destroy (gpointer data)
 }
 
 /**
- * spiel_speaker_new:
+ * spiel_speaker_new: (finish-func spiel_speaker_new_finish)
  * @cancellable: (nullable): optional `GCancellable`.
  * @callback: A #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: User data to pass to @callback.


### PR DESCRIPTION
GObject-Introspection now supports annotating the async/finish functions, although the language bindings must support this to allow automatic `await` support.

In the most current release the GIR compiler, and probably gi-docgen, will emit warning if it can't match find a matching pair of `some_async()`/`some_finish()`, as is the case with `spiel_speaker_new()` and `spiel_speaker_new_finish()`.

The patch adds that annotation, but should be verified to pass the CI on a GNOME 46 distribution before merge or it may result in an error on older versions.