### PR TITLE
spiel-registry: assert before chaining-up in finalize

### DIFF
--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -432,9 +432,10 @@ spiel_registry_finalize (GObject *object)
       g_clear_object (&self->connection);
     }
 
-  G_OBJECT_CLASS (spiel_registry_parent_class)->finalize (object);
   g_assert (object == G_OBJECT (sRegistry));
   sRegistry = NULL;
+
+  G_OBJECT_CLASS (spiel_registry_parent_class)->finalize (object);
 }
 
 static gboolean


### PR DESCRIPTION
It seems like the memory pointer should still be valid, however it's possible the `G_OBJECT()` cast is failing post-finalize and causing the assertion to fail.

closes #55