### PR TITLE
Add additional readme context on installing or using spiel in client code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ meson compile -C build
 
 Once Spiel is built, to run test the Python example above or a similar GObject client, make sure you are inside the build environment by running `meson devenv -C build`.
 
-To install libspiel system wide and expose it to GObject client code without needing to run `meson devenv`, run $TODO_NOT_SURE
+To install libspiel system wide and expose it to GObject client code without needing to run `meson devenv`, run `meson install -C build`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ meson setup build
 meson compile -C build
 ```
 
+Once Spiel is built, to run test the Python example above or a similar GObject client, make sure you are inside the build environment by running `meson devenv -C build`.
+
+To install libspiel system wide and expose it to GObject client code without needing to run `meson devenv`, run $TODO_NOT_SURE
+
 ## Documentation
 
 There is an [auto-generated API reference](https://project-spiel.org/libspiel/).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ meson compile -C build
 
 Once Spiel is built, to run test the Python example above or a similar GObject client, make sure you are inside the build environment by running `meson devenv -C build`.
 
-To install libspiel system wide and expose it to GObject client code without needing to run `meson devenv`, run `meson install -C build`
+To install libspiel system wide without needing to run `meson devenv`, run `meson install -C build`
 
 ## Documentation
 


### PR DESCRIPTION
I think it is useful to add  additional context, especially for those who are less exposed to using `meson` , regarding how to use libspiel in GObject client code.  Currently the readme does not specify how for developers.

This PR adds the context I was given in the Gnome Matrix a11y channel.

Once this is merged, it will resolve https://github.com/project-spiel/libspiel/issues/62