### PR TITLE
Install generated spiel-provider-proxy.h file

### DIFF
--- a/libspiel/meson.build
+++ b/libspiel/meson.build
@@ -8,6 +8,7 @@ spiel_iface_sources = gnome.gdbus_codegen(
     annotations : [
       ['org.freedesktop.Speech.Provider', 'org.gtk.GDBus.C.Name', 'ProviderProxy']
     ],
+    install_header : true,
     extra_args: '--glib-min-required=2.64')
 
 python_module = import('python')


### PR DESCRIPTION
In commit e1e6181aeaf526aae35402293d050e3beb25fd08 this header was made public but wasn't made installable with Meson, leading to include errors in apps making use of the spiel.h header.