### PR TITLE
Install spiel-provider-proxy.h in a correct path

### DIFF
--- a/libspiel/meson.build
+++ b/libspiel/meson.build
@@ -8,7 +8,8 @@ spiel_iface_sources = gnome.gdbus_codegen(
     annotations : [
       ['org.freedesktop.Speech.Provider', 'org.gtk.GDBus.C.Name', 'ProviderProxy']
     ],
-    install_header : true,
+    install_header: true,
+    install_dir: join_paths(get_option('includedir'), 'spiel'),
     extra_args: '--glib-min-required=2.64')
 
 python_module = import('python')


### PR DESCRIPTION
As of now the header is dumped straight into `/usr/include`, which is presumably unwanted